### PR TITLE
remove date question

### DIFF
--- a/docassemble/SMPDecisionTree/data/questions/software.yml
+++ b/docassemble/SMPDecisionTree/data/questions/software.yml
@@ -1196,7 +1196,7 @@ attachment code: |
 ---
 attachment:
   name: Human Readable Software Management Plan for `${ software_name }`
-  filename: Software_Management_Plan_${ space_to_underscore(software_name) }
+  filename: Software_Management_Plan-${ space_to_underscore(software_name) }-${ release_date.strftime('%y_%m_%d') }
   docx template file: SMP_decision_tree_template_3.docx
   valid formats:
   #  - md

--- a/docassemble/SMPDecisionTree/data/questions/software.yml
+++ b/docassemble/SMPDecisionTree/data/questions/software.yml
@@ -23,6 +23,7 @@ code: |
   community = False
   reuse = False
   smp_version = "0.1.0"
+  release_date = today()
 ---
 objects:
   - authors: |
@@ -194,15 +195,6 @@ subquestion: |
 fields:
   - Version: smp_version
     default: 0.1.0
----
-mandatory: True
-question: Software Management Plan Release Date
-subquestion: |
-  What is the release date of the Software Management Plan?
-fields:
-  - Release Date: release_date
-    datatype: date
-    default: ${ today() }
 ---
 mandatory: True
 question: |


### PR DESCRIPTION
Fixes #16 and #17 

Removes the question for the release date, simply setting it to `today()`, and including it in `yyyy_mm_dd` format in the downloaded filename.