### PR TITLE
Add bump-my-version config file

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,29 @@
+[tool.bumpversion]
+current_version = "0.0.4"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
+serialize = ["{major}.{minor}.{patch}"]
+search = "{current_version}"
+replace = "{new_version}"
+regex = false
+ignore_missing_version = false
+tag = false
+sign_tags = false
+tag_name = "v{new_version}"
+tag_message = "Bump version: {current_version} → {new_version}"
+allow_dirty = false
+commit = false
+message = "Bump version: {current_version} → {new_version}"
+commit_args = ""
+
+[[tool.bumpversion.files]]
+filename = "setup.py"
+
+[[tool.bumpversion.files]]
+filename = ".bumpversion.toml"
+
+[[tool.bumpversion.files]]
+filename = "docassemble/SMPDecisionTree/__init__.py"
+
+[[tool.bumpversion.files]]
+filename = "docassemble/SMPDecisionTree/data/questions/software.yml"
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `bump-my-version` support for version releases
+
 ### Changed
 
 ### Removed

--- a/README.dev.md
+++ b/README.dev.md
@@ -1,0 +1,45 @@
+## Versioning
+
+To progress version numbers e.g. upon a new release, we use `bump-my-version`.
+
+### Installation
+This Python tool can be installed via either `pip` or `pipx`:
+
+```bash
+# Create desired environment first
+pip install bump-my-version
+
+# Have pipx installed in a global/tooling environment
+pipx install bump-my-version
+```
+
+### Tracking which files to update
+`bump-my-version` will only search in files indicated in the `.bumpversion.toml` file.
+If the version number needs to be tracked and updated in a new file, you have to add
+the following entry in the configuration file:
+
+```toml
+[[tool.bumpversion.files]]
+filename = "path/to/file.txt"
+```
+
+Doing a dry run (see next section) is recommended to confirm your addition has been
+successful.
+
+### Bumping version
+Using the `show-bump` command, you can see which common bump options are available:
+
+```bash
+$ bump-my-version show-bump
+0.0.4 ── bump ─┬─ major ─ 1.0.0
+               ├─ minor ─ 0.1.0
+               ╰─ patch ─ 0.0.5
+```
+
+To see which entries in which files would be updated, you can do a dry run:
+```bash
+$ bump-my-version --dry-run --verbose patch
+```
+
+If you are satisfied with the result, you can omit the `--dry-run` and `--verbose` options.
+You will still have to stage and commit the resulting changes to the repository.


### PR DESCRIPTION
Resolves #58 

Adds the `.bumpversion.toml` config file, and instructions on how to use `bump-my-version` in a new README.dev.md file.