### PR TITLE
fix(software.yml): Remove the text "your software"

### DIFF
--- a/docassemble/SMPDecisionTree/data/questions/software.yml
+++ b/docassemble/SMPDecisionTree/data/questions/software.yml
@@ -1177,7 +1177,7 @@ mandatory: True
 question: |
   Risk Analysis
 subquestion: |
-  Consider other factors that could have an impact on `${ software_name }`, or could be caused by `${ software_name }`your software. For example compliance with privacy policies, security considerations, reliability requirements, portability / vendor lock-in, etc.
+  Consider other factors that could have an impact on `${ software_name }`, or could be caused by `${ software_name }`. For example compliance with privacy policies, security considerations, reliability requirements, portability / vendor lock-in, etc.
 
   Describe the main external factors that should be considered by developers and users of the Software. These could include data privacy, information security, etc.
 


### PR DESCRIPTION
This PR removes the text "your software" right after the user-provided project name. Since the user-specified software name is already provided, I think it's ok without the text, "your software" as below:


Before: 
> ...or could be caused by `My Project`your software.


After: 
> ...or could be caused by `My Project`.