### PR TITLE
enable navigation bar

### DIFF
--- a/docassemble/SMPDecisionTree/data/questions/access.yml
+++ b/docassemble/SMPDecisionTree/data/questions/access.yml
@@ -1,5 +1,11 @@
 ---
 mandatory: True
+section: section_access
+# When setting the `public` variable in this section, we want to recalculate the items in the navigation bar.
+# In the root .yml file there is a code section that sets a dummy `navigation_recalculated` variable.
+# By depending on (`depends on`) this variable here, we force it to be re-evaluated and thus re-run the navigation sections code.
+# TODO This is very clunky. If there's an easier way, feel free to improve this.
+depends on: navigation_recalculated
 question: |
   Software Access
 subquestion: |
@@ -31,4 +37,12 @@ fields:
 terms:
   publicly available: |
     Available on a accessible and searchable platform, where anyone can find it.
+---
+# When clicking on the navigation section "Access", ask again the question that defines the variable `public`.
+event: section_access
+code: force_ask('public')
+---
+# When clicking on the navigation section "Scope", ask again the question that defines the variable `public`.
+event: section_scope
+code: force_ask('public')
 ---

--- a/docassemble/SMPDecisionTree/data/questions/attribution.yml
+++ b/docassemble/SMPDecisionTree/data/questions/attribution.yml
@@ -1,4 +1,5 @@
 ---
+section: section_authors
 question: |
   Authors
 subquestion: |
@@ -12,6 +13,7 @@ fields:
     hint: jane_doe@example.com
     datatype: email
 ---
+section: section_authors
 mandatory: True
 question: |
   Review Authors
@@ -27,9 +29,23 @@ subquestion: |
   Note: The first person will be used as primary contact.
   ${ authors.table }
   ${ authors.add_action() }
+# Create a hidden field. `force_ask` needs an actual variable definition to jump back to.
+fields:
+  - field: authors_revisited
+    input type: hidden
+    default: "no"
 continue button field: authors_ok
 ---
+# When clicking on the navigation section "Authors", ask again the question that defines the variable `authors_revisited`.
+event: section_authors
+code: force_ask('authors_revisited')
+---
+# When clicking on the navigation section "Authors", ask again the question that defines the variable `authors_revisited`.
+event: section_smp
+code: force_ask('authors_revisited')
+---
 mandatory: True
+section: section_ownership
 question: |
   Ownership
 subquestion: |
@@ -41,7 +57,12 @@ fields:
     hint: University of Springfield, Department of Nuclear Physics
     input type: area
 ---
+# When clicking on the navigation section "Ownership", ask again the question that defines the variable `ownership`.
+event: section_ownership
+code: force_ask('ownership')
+---
 mandatory: True
+section: section_context
 question: |
   Research Project Context
 subquestion: |
@@ -53,7 +74,12 @@ fields:
     input type: area
     rows: 10
 ---
+# When clicking on the navigation section "Context", ask again the question that defines the variable `research_project_context`.
+event: section_context
+code: force_ask('research_project_context')
+---
 mandatory: public
+section: section_citation
 question: |
   Citation
 subquestion: |
@@ -77,4 +103,8 @@ fields:
     hint: "CFF file in the repository (link: ...), DOI on Zenodo (link: ...)"
     input type: area
     rows: 10
+---
+# When clicking on the navigation section "Citation", ask again the question that defines the variable `citation`.
+event: section_citation
+code: force_ask('citation')
 ---

--- a/docassemble/SMPDecisionTree/data/questions/community.yml
+++ b/docassemble/SMPDecisionTree/data/questions/community.yml
@@ -1,5 +1,11 @@
 ---
 mandatory: reuse
+section: section_multi_user
+# When setting the `multi_user` variable in this section, we want to recalculate the items in the navigation bar.
+# In the root .yml file there is a code section that sets a dummy `navigation_recalculated` variable.
+# By depending on (`depends on`) this variable here, we force it to be re-evaluated and thus re-run the navigation sections code.
+# TODO This is very clunky. If there's an easier way, feel free to improve this.
+depends on: navigation_recalculated
 question: |
   Users/Collaborators
 subquestion: |
@@ -34,7 +40,12 @@ subquestion: |
   <br>
 yesno: multi_user
 ---
+# When clicking on the navigation section "Users", ask again the question that defines the variable `multi_user`.
+event: section_multi_user
+code: force_ask('multi_user')
+---
 mandatory: multi_user
+section: section_community
 question: |
   Community
 subquestion: |
@@ -63,4 +74,8 @@ terms:
   community: |
     A group of people, generally outside your direct collaborators or contacts, that is using or developing the software (semi-)autonomously.
 yesno: community
+---
+# When clicking on the navigation section "Community", ask again the question that defines the variable `community`.
+event: section_community
+code: force_ask('community')
 ---

--- a/docassemble/SMPDecisionTree/data/questions/dmp.yml
+++ b/docassemble/SMPDecisionTree/data/questions/dmp.yml
@@ -1,5 +1,6 @@
 ---
 mandatory: True
+section: section_dmp
 question: |
   Data Management Plan
 subquestion: |
@@ -11,4 +12,8 @@ fields:
     hint: "We are using web-scraped Facebook data and output a list of potential burglary victims in The Netherlands. Our DMP can be found here: https://dmp.example.com"
     input type: area
     rows: 10
+---
+# When clicking on the navigation section "DMP", ask again the question that defines the variable `data_management_plan`.
+event: section_dmp
+code: force_ask('data_management_plan')
 ---

--- a/docassemble/SMPDecisionTree/data/questions/documentation.yml
+++ b/docassemble/SMPDecisionTree/data/questions/documentation.yml
@@ -1,5 +1,6 @@
 ---
 mandatory: public or reuse or multi_user
+section: section_documentation
 question: |
   Documentation
 subquestion: |
@@ -55,4 +56,7 @@ fields:
     input type: area
     rows: 10
 ---
-
+# When clicking on the navigation section "Documentation", ask again the question that defines the variable `documentation`.
+event: section_documentation
+code: force_ask('user_documentation')
+---

--- a/docassemble/SMPDecisionTree/data/questions/introduction.yml
+++ b/docassemble/SMPDecisionTree/data/questions/introduction.yml
@@ -1,5 +1,6 @@
 ---
 mandatory: True
+section: section_introduction
 question: |
   Hi!
 subquestion: |
@@ -10,6 +11,7 @@ subquestion: |
   When completed, you can download an overview of your answers as your SMP. This can serve as reference for yourself and as an overview for any technical support staff you may consult with later.
 
   💡 Note that many of the questions are optional. It's fine if you don't answer these yet. However, we urge you to at least consider their benefit to your software. Having an answer to all of them at some point may well improve the impact of your software.
+
 terms:
   SMP: |
     SMP: Software Management Plan; terms that deserve some context will be explained is these pop-ups.

--- a/docassemble/SMPDecisionTree/data/questions/license.yml
+++ b/docassemble/SMPDecisionTree/data/questions/license.yml
@@ -1,5 +1,6 @@
 ---
 mandatory: public
+section: section_license
 question: |
   License
 subquestion: |
@@ -697,4 +698,8 @@ fields:
       is: Other
     hint: Please explain why an SPDX-type license does not suffice
     input type: area
+---
+# When clicking on the navigation section "License", ask again the question that defines the variable `software_license`.
+event: section_license
+code: force_ask('software_license')
 ---

--- a/docassemble/SMPDecisionTree/data/questions/name_purpose.yml
+++ b/docassemble/SMPDecisionTree/data/questions/name_purpose.yml
@@ -1,5 +1,6 @@
 ---
 mandatory: True
+section: section_name_purpose
 question: |
   Software Name & Purpose
 fields:
@@ -26,4 +27,8 @@ fields:
     hint: This BASH script proves the Hauptvermutung conjecture and generates some visual examples. It is intended to be used by the general math community. We are developing this software because no prior software like this exists since no one else proved the Hauptvermutung.
     input type: area
     rows: 10
+---
+# When clicking on the navigation section "Name & Purpose", ask again the question that defines the variable `software_name`.
+event: section_name_purpose
+code: force_ask('software_name')
 ---

--- a/docassemble/SMPDecisionTree/data/questions/reuse.yml
+++ b/docassemble/SMPDecisionTree/data/questions/reuse.yml
@@ -1,5 +1,11 @@
 ---
 mandatory: True
+section: section_reuse
+# When setting the `reuse` variable in this section, we want to recalculate the items in the navigation bar.
+# In the root .yml file there is a code section that sets a dummy `navigation_recalculated` variable.
+# By depending on (`depends on`) this variable here, we force it to be re-evaluated and thus re-run the navigation sections code.
+# TODO This is very clunky. If there's an easier way, feel free to improve this.
+depends on: navigation_recalculated
 question: |
   Reuse/Reproduce
 subquestion: |
@@ -34,4 +40,8 @@ subquestion: |
   </details>
   <br>
 yesno: reuse
+---
+# When clicking on the navigation section "Reuse", ask again the question that defines the variable `reuse`.
+event: section_reuse
+code: force_ask('reuse')
 ---

--- a/docassemble/SMPDecisionTree/data/questions/risks.yml
+++ b/docassemble/SMPDecisionTree/data/questions/risks.yml
@@ -1,5 +1,6 @@
 ---
 mandatory: True
+section: section_risks
 question: |
   Risk Analysis
 subquestion: |
@@ -18,4 +19,8 @@ fields:
     hint: Right now our university department discourages the use of our ChatGPT software to filter new applicants. We are actively working with management to change that.
     input type: area
     rows: 10
+---
+# When clicking on the navigation section "Risks", ask again the question that defines the variable `risk_analysis`.
+event: section_risks
+code: force_ask('risk_analysis')
 ---

--- a/docassemble/SMPDecisionTree/data/questions/software.yml
+++ b/docassemble/SMPDecisionTree/data/questions/software.yml
@@ -18,15 +18,16 @@ metadata:
     - software
 ---
 features:
-  navigation: False
+  navigation: True
   progress bar: False
 ---
 mandatory: True
 code: |
-  smp_decision_tree_version = "0.0.5"
-  community = False
-  reuse = False
-  multi_user = False
+  smp_decision_tree_version = "0.0.6"
+  community = None
+  reuse = None
+  multi_user = None
+  public = None
   smp_version = "0.1.0"
   release_date = today()
 ---
@@ -47,6 +48,86 @@ edit:
   - name
   - address
 allow reordering: True
+---
+initial: True
+code: |
+
+  # TODO Right now we have to duplicate the questionnaire flow logic here. Can we generate this instead?
+
+  # When setting switch question variables, we want to recalculate the items in the navigation bar.
+  # This code sets a dummy `navigation_recalculated` variable.
+  # By having the switch question variables depend on (`depends on`) this variable here, we force `navigation_recalculated` to be re-evaluated and thus re-run this code.
+  # TODO This is very clunky. If there's an easier way, feel free to improve this.
+
+  scope_sections = {'section_scope': 'Scope', 'subsections': [{'section_access': 'Access'}, {'section_reuse': 'Reuse'}]}
+
+  if not reuse is False:
+    scope_sections['subsections'].append({'section_multi_user': 'Users'})
+  else:
+    multi_user = False
+
+  if not multi_user is False:
+    scope_sections['subsections'].append({'section_community': 'Community'})
+  else:
+    community = False
+
+  software_management_sections = {'section_smp': 'Software Management', 'subsections': [{'section_authors': 'Authors'}, {'section_ownership': 'Ownership'}, {'section_context': 'Context'}]}
+
+  if not public is False:
+    software_management_sections['subsections'].append({'section_citation': 'Citation'})
+
+  software_management_sections['subsections'].append({'section_versioning': 'Versioning'})
+
+  if not public is False:
+    software_management_sections['subsections'].append({'section_license': 'License'})
+
+  if not (public is False) or not (reuse is False) or not (multi_user is False):
+    software_management_sections['subsections'].append({'section_documentation': 'Documentation'})
+
+  if not multi_user is False:
+    software_management_sections['subsections'].append({'section_maintenance': 'Maintenance'})
+
+  if not community is False:
+    software_management_sections['subsections'].append({'section_sustainability': 'Sustainability'})
+    software_management_sections['subsections'].append({'section_support': 'Support'})
+
+  if not (reuse is False) or not (multi_user is False):
+    software_management_sections['subsections'].append({'section_quality': 'Quality'})
+
+  if not reuse is False:
+    software_management_sections['subsections'].append({'section_packaging': 'Packaging'})
+
+  software_management_sections['subsections'].append({'section_risks': 'Risks'})
+  software_management_sections['subsections'].append({'section_dmp': 'DMP'})
+
+  the_sections =  [{'section_introduction': 'Introduction'}, {'section_name_purpose': 'Name & Purpose'}] + [scope_sections, software_management_sections]
+  nav.set_sections(the_sections)
+
+  navigation_recalculated = True
+---
+sections:
+  - section_introduction: Introduction
+  - section_name_purpose: Name & Purpose
+#  - Scope:
+#    - section_access: Access
+#    - section_reuse: Reuse
+#    - section_multi_user: Users
+#    - section_community: Community
+#  - Software Management:
+#    - section_authors: Authors
+#    - section_ownership: Ownership
+#    - section_context: Context
+#    - section_citation: Citation
+#    - section_versioning: Versioning
+#    - section_license: License
+#    - section_documentation: Documentation
+#    - section_maintenance: Maintenance
+#    - section_sustainability: Sustainability
+#    - section_support: Support
+#    - section_quality: Quality
+#    - section_packaging: Packaging
+#    - section_risks: Risks
+#    - section_dmp: DMP
 ---
 ### Start questionnaire
 include:

--- a/docassemble/SMPDecisionTree/data/questions/sustainability.yml
+++ b/docassemble/SMPDecisionTree/data/questions/sustainability.yml
@@ -1,5 +1,6 @@
 ---
 mandatory: multi_user
+section: section_maintenance
 question: |
   Maintenance
 subquestion: |
@@ -15,7 +16,12 @@ fields:
     input type: area
     rows: 10
 ---
+# When clicking on the navigation section "Maintenance", ask again the question that defines the variable `maintenance`.
+event: section_maintenance
+code: force_ask('maintenance')
+---
 mandatory: community
+section: section_sustainability
 question: |
   Sustainability
 subquestion: |
@@ -44,7 +50,12 @@ terms:
   RSE: |
     Research Software Engineer.
 ---
+# When clicking on the navigation section "Sustainability", ask again the question that defines the variable `sustainability`.
+event: section_sustainability
+code: force_ask('sustainability')
+---
 mandatory: community
+section: section_support
 question: |
   Support
 subquestion: |
@@ -63,7 +74,12 @@ fields:
     input type: area
     rows: 10
 ---
+# When clicking on the navigation section "Support", ask again the question that defines the variable `support`.
+event: section_support
+code: force_ask('support')
+---
 mandatory: reuse or multi_user
+section: section_quality
 question: |
   Code Quality
 fields:
@@ -125,7 +141,12 @@ terms:
   linter: |
     A development tool that performs static code analysis, and checks (and possibly corrects) the code style.
 ---
+# When clicking on the navigation section "Quality", ask again the question that defines the variable `quality`.
+event: section_quality
+code: force_ask('quality')
+---
 mandatory: reuse
+section: section_packaging
 question: |
   Packaging
 subquestion: |
@@ -143,4 +164,8 @@ fields:
     hint: "XZ Utils will be packaged on Pypi (link: ...) and conda (link: ...)"
     input type: area
     rows: 10
+---
+# When clicking on the navigation section "Packaging", ask again the question that defines the variable `packaging`.
+event: section_packaging
+code: force_ask('packaging')
 ---

--- a/docassemble/SMPDecisionTree/data/questions/versioning.yml
+++ b/docassemble/SMPDecisionTree/data/questions/versioning.yml
@@ -1,5 +1,6 @@
 ---
 mandatory: True
+section: section_versioning
 question: |
   Version Control
 subquestion: |
@@ -65,4 +66,8 @@ fields:
     rows: 10
     show if:
       code: public or reuse
+---
+# When clicking on the navigation section "Versioning", ask again the question that defines the variable `version_scheme`.
+event: section_versioning
+code: force_ask('version_scheme')
 ---


### PR DESCRIPTION
> [!WARNING]  
> This PR needs thorough testing before merging.

Features:
- Assign "sections" to questionnaire pages
- Recalculate navigation bar items after answering switch questions
  - Some questions might be skipped
  - Also works mid-questionnaire
- Clicking navigation bar items `force_ask`s the question again
  - This simulates jumping back to that section
- After altering navigation, clicking "next" brings the users to the next _unanswered_ question, disregarding visual order

Bugs:
- After adding/removing questions / navigation bar items, the color coding of answered/unanswered questions is not correct. The actual order in which questions are asked is correct, though.

Closes #15